### PR TITLE
INTERLOK-2658 spotbugs

### DIFF
--- a/src/main/java/com/adaptris/vertx/InterlokService.java
+++ b/src/main/java/com/adaptris/vertx/InterlokService.java
@@ -41,14 +41,18 @@ public class InterlokService {
     this.state = state;
   }
   
+  @Override
   public boolean equals(Object object) {
+    if (object == this) return true;
     if(object instanceof InterlokService) {
-      if(((InterlokService) object).getId().equals(this.getId()))
-        return true;
-      else
-        return false;
+      return getId().equals(((InterlokService) object).getId());
     } else
       return false;
+  }
+
+  @Override
+  public int hashCode() {
+    return getId().hashCode();
   }
 
   public Exception getException() {
@@ -59,6 +63,7 @@ public class InterlokService {
     this.exception = exception;
   }
   
+  @Override
   public String toString() {
     return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE).append("id", getId()).append("state", getState().name())
         .append("Exception", this.getException() != null).toString();

--- a/src/main/java/com/adaptris/vertx/InterlokService.java
+++ b/src/main/java/com/adaptris/vertx/InterlokService.java
@@ -2,7 +2,7 @@ package com.adaptris.vertx;
 
 import org.apache.commons.lang.builder.ToStringBuilder;
 import org.apache.commons.lang.builder.ToStringStyle;
-
+import com.adaptris.util.GuidGenerator;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 @XStreamAlias("clustered-interlok-service")
@@ -13,7 +13,7 @@ public class InterlokService {
   private Exception exception;
   
   public InterlokService() {
-    // no arg for marshalling
+    this(new GuidGenerator().getUUID());
   }
   
   public InterlokService(String id) {
@@ -65,7 +65,8 @@ public class InterlokService {
   
   @Override
   public String toString() {
-    return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE).append("id", getId()).append("state", getState().name())
+    return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE).append("id", getId())
+        .append("state", getState().name())
         .append("Exception", this.getException() != null).toString();
   }
 }

--- a/src/main/java/com/adaptris/vertx/VertXMessage.java
+++ b/src/main/java/com/adaptris/vertx/VertXMessage.java
@@ -1,7 +1,6 @@
 package com.adaptris.vertx;
 
 import org.apache.commons.lang.builder.EqualsBuilder;
-
 import com.adaptris.core.SerializableAdaptrisMessage;
 import com.adaptris.util.GuidGenerator;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
@@ -20,6 +19,11 @@ public class VertXMessage {
     adaptrisMessage = new SerializableAdaptrisMessage(new GuidGenerator().getUUID());
   }
   
+  public VertXMessage(SerializableAdaptrisMessage msg) {
+    this();
+    setAdaptrisMessage(msg);
+  }
+
   public SerializableAdaptrisMessage getAdaptrisMessage() {
     return adaptrisMessage;
   }

--- a/src/main/java/com/adaptris/vertx/VertXMessage.java
+++ b/src/main/java/com/adaptris/vertx/VertXMessage.java
@@ -3,6 +3,7 @@ package com.adaptris.vertx;
 import org.apache.commons.lang.builder.EqualsBuilder;
 
 import com.adaptris.core.SerializableAdaptrisMessage;
+import com.adaptris.util.GuidGenerator;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 @XStreamAlias("clustered-message")
@@ -16,6 +17,7 @@ public class VertXMessage {
   
   public VertXMessage() {
     serviceRecord = new ServiceRecord();
+    adaptrisMessage = new SerializableAdaptrisMessage(new GuidGenerator().getUUID());
   }
   
   public SerializableAdaptrisMessage getAdaptrisMessage() {
@@ -42,6 +44,7 @@ public class VertXMessage {
     this.startProcessingTime = startProcessingTime;
   }
   
+  @Override
   public String toString() {
     StringBuilder builder = new StringBuilder();
     builder.append("Start processing at :" + this.getStartProcessingTime());
@@ -56,15 +59,21 @@ public class VertXMessage {
    * If the unique id's are the same then equals will return true.
    * @see java.lang.Object#equals(java.lang.Object)
    */
+  @Override
   public boolean equals(Object object) {
-    if(!(object instanceof VertXMessage))
-      return false;
-    else {
+    if (object == this)
+      return true;
+    if (object instanceof VertXMessage) {
       VertXMessage otherInstance = (VertXMessage) object;
       return new EqualsBuilder()
             .append(this.getAdaptrisMessage().getUniqueId(), otherInstance.getAdaptrisMessage().getUniqueId())
             .isEquals();
     }
+    return false;
   }
 
+  @Override
+  public int hashCode() {
+    return this.getAdaptrisMessage().getUniqueId().hashCode();
+  }
 }

--- a/src/main/java/com/adaptris/vertx/util/BlockingExpiryQueue.java
+++ b/src/main/java/com/adaptris/vertx/util/BlockingExpiryQueue.java
@@ -34,7 +34,7 @@ public class BlockingExpiryQueue<T> extends ArrayBlockingQueue<T> {
   
   private transient List<ExpiryListener<T>> expiryListeners;
   
-  private TimeInterval expiryTimeout;
+  private transient TimeInterval expiryTimeout;
 
   public BlockingExpiryQueue(int capacity) {
     this(capacity, true);

--- a/src/test/java/com/adaptris/vertx/InterlokServiceTest.java
+++ b/src/test/java/com/adaptris/vertx/InterlokServiceTest.java
@@ -1,18 +1,27 @@
 package com.adaptris.vertx;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
 import com.adaptris.core.CoreException;
 
-import junit.framework.TestCase;
-
-public class InterlokServiceTest extends TestCase {
+public class InterlokServiceTest {
   
+  @Test
   public void testEquals() {
     InterlokService interlokService1 = new InterlokService("id1");
     InterlokService interlokService2 = new InterlokService("id1");
     
     assertEquals(interlokService1, interlokService2);
+    assertEquals(interlokService1.hashCode(), interlokService2.hashCode());
+    assertFalse(interlokService1.equals(new Object()));
+    assertTrue(interlokService1.equals(interlokService1));
+    assertFalse(interlokService1.equals(new InterlokService()));
   }
   
+  @Test
   public void testEqualsTrueWithDifferentStates() {
     InterlokService interlokService1 = new InterlokService("id1");
     interlokService1.setState(ServiceState.COMPLETE);
@@ -21,8 +30,10 @@ public class InterlokServiceTest extends TestCase {
     interlokService2.setState(ServiceState.NOT_STARTED);
     
     assertEquals(interlokService1, interlokService2);
+    assertEquals(interlokService1.hashCode(), interlokService2.hashCode());
   }
   
+  @Test
   public void testEqualsTrueWithExceptionSet() {
     InterlokService interlokService1 = new InterlokService("id1");
     interlokService1.setException(new CoreException("TestException"));;
@@ -30,6 +41,15 @@ public class InterlokServiceTest extends TestCase {
     InterlokService interlokService2 = new InterlokService("id1");
     
     assertEquals(interlokService1, interlokService2);
+    assertEquals(interlokService1.hashCode(), interlokService2.hashCode());
+  }
+
+  @Test
+  public void testToString() {
+    InterlokService srv1 = new InterlokService();
+    assertNotNull(srv1.toString());
+    srv1.setException(new Exception());
+    assertNotNull(srv1.toString());
   }
 
 }

--- a/src/test/java/com/adaptris/vertx/VertxMessageTest.java
+++ b/src/test/java/com/adaptris/vertx/VertxMessageTest.java
@@ -1,0 +1,34 @@
+package com.adaptris.vertx;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+import com.adaptris.core.SerializableAdaptrisMessage;
+
+public class VertxMessageTest {
+  
+  @Test
+  public void testEquals() {
+    SerializableAdaptrisMessage msg = new SerializableAdaptrisMessage("id1");
+    VertXMessage m1 = new VertXMessage(msg);
+    VertXMessage m2 = new VertXMessage(msg);
+    
+    assertEquals(m1, m2);
+    assertEquals(m1.hashCode(), m2.hashCode());
+    assertTrue(m1.equals(m1));
+    assertFalse(m1.equals(new Object()));
+    assertNotEquals(m1, new VertXMessage());
+  }
+  
+
+  @Test
+  public void testToString() {
+    SerializableAdaptrisMessage msg = new SerializableAdaptrisMessage("id1");
+    VertXMessage m1 = new VertXMessage(msg);
+    assertNotNull(m1.toString());
+  }
+
+}


### PR DESCRIPTION
- Fix HE_EQUALS_USE_HASHCODE
- Mark expiryTimeout as transient.

The change to expiryTimeout is the one that concerns me the most; from usage, we don't expect to serialize the class, but it would be possible since the superclass implements serializable; 

Since TimeInterval isn't serializable (it could be, since it just wraps an enum+long value), if we serialize/unserialize, then we're left with the default expiry.