### PR TITLE
INTERLOK-2808 Our Vertx services as message backed processing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ ext {
   organizationName = "Adaptris Ltd"
   organizationUrl = "http://interlok.adaptris.net"
   slf4jVersion = '1.7.28'
-  vertxVersion = '3.5.4'
+  vertxVersion = '3.8.2'
   log4j2Version = '2.12.1'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -105,6 +105,7 @@ dependencies {
 
   testCompile ('junit:junit:4.12')
   testCompile ('org.mockito:mockito-all:1.10.19')
+  testCompile ('org.awaitility:awaitility:4.0.1')
   testCompile ("com.adaptris:interlok-stubs:$interlokCoreVersion") { changing= true }
   testCompile ("org.apache.logging.log4j:log4j-core:$log4j2Version")
   testCompile ("org.apache.logging.log4j:log4j-1.2-api:$log4j2Version")

--- a/build.gradle
+++ b/build.gradle
@@ -98,7 +98,7 @@ dependencies {
     exclude group: 'com.fasterxml.jackson.core', module: 'jackson-databind'
   }
   compile ("com.fasterxml.jackson.core:jackson-databind:2.10.0")
-  compile ("com.hazelcast:hazelcast:3.12.1")
+  compile ("com.hazelcast:hazelcast:3.12.3")
 
   annotationProcessor ("com.adaptris:interlok-common:$interlokCoreVersion") {changing= true}
   umlDoclet("nl.talsmasoftware:umldoclet:1.1.4")

--- a/src/main/java/com/adaptris/vertx/VertxService.java
+++ b/src/main/java/com/adaptris/vertx/VertxService.java
@@ -29,6 +29,7 @@ import com.adaptris.core.ServiceWrapper;
 import com.adaptris.core.common.ConstantDataInputParameter;
 import com.adaptris.core.util.LifecycleHelper;
 import com.adaptris.core.util.LoggingHelper;
+import com.adaptris.core.util.ManagedThreadFactory;
 import com.adaptris.interlok.InterlokException;
 import com.adaptris.interlok.config.DataInputParameter;
 import com.adaptris.util.NumberUtils;
@@ -225,7 +226,7 @@ public class VertxService extends ServiceImp implements Handler<Message<VertXMes
     LifecycleHelper.close(this.getReplyService());
     LifecycleHelper.close(this.getReplyServiceExceptionHandler());
     
-    this.getExecutorService().shutdown();
+    ManagedThreadFactory.shutdownQuietly(this.getExecutorService(), 30000l);
   }
 
   public Service getService() {
@@ -365,11 +366,11 @@ public class VertxService extends ServiceImp implements Handler<Message<VertXMes
     }
   }
 
-  public ExecutorService getExecutorService() {
+  ExecutorService getExecutorService() {
     return executorService;
   }
 
-  public void setExecutorService(ExecutorService executorService) {
+  void setExecutorService(ExecutorService executorService) {
     this.executorService = executorService;
   }
   

--- a/src/main/java/com/adaptris/vertx/VertxService.java
+++ b/src/main/java/com/adaptris/vertx/VertxService.java
@@ -2,6 +2,11 @@ package com.adaptris.vertx;
 
 import static com.adaptris.core.util.ServiceUtil.discardNulls;
 
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
@@ -26,6 +31,7 @@ import com.adaptris.core.util.LifecycleHelper;
 import com.adaptris.core.util.LoggingHelper;
 import com.adaptris.interlok.InterlokException;
 import com.adaptris.interlok.config.DataInputParameter;
+import com.adaptris.util.NumberUtils;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 import io.vertx.core.Handler;
@@ -78,8 +84,9 @@ import io.vertx.core.eventbus.MessageCodec;
 @ComponentProfile(summary = "Allows clustered single service processing.", tag = "service,clustering,vertx")
 @XStreamAlias("clustered-service")
 @DisplayOrder(order = {"clusterId", "targetSendMode"})
-public class VertxService extends ServiceImp
-    implements Handler<Message<VertXMessage>>, ConsumerEventListener, ServiceWrapper {
+public class VertxService extends ServiceImp implements Handler<Message<VertXMessage>>, ConsumerEventListener, ServiceWrapper {
+  
+  private static final int DEFAULT_MAX_THREADS = 10;
   
   private String clusterId;
   
@@ -109,13 +116,17 @@ public class VertxService extends ServiceImp
   private transient ClusteredEventBus clusteredEventBus;
   private transient ConsumerLatch latch;
   
+  private transient ExecutorService executorService;
+  
+  private Integer maxThreads;
+  
   public VertxService() {
     super();
     this.setMessageCodec(new AdaptrisMessageCodec());
     this.setTargetSendMode(SendMode.Mode.SINGLE);
     this.setTargetComponentId(new ConstantDataInputParameter());
-    clusteredEventBus = new ClusteredEventBus();
-    clusteredEventBus.setMessageCodec(getMessageCodec());
+    this.setClusteredEventBus(new ClusteredEventBus());
+    this.getClusteredEventBus().setMessageCodec(getMessageCodec());
   }
 
   @Override
@@ -126,14 +137,10 @@ public class VertxService extends ServiceImp
       translatedMessage.setStartProcessingTime(System.currentTimeMillis());
       
       if((this.getTargetComponentId() != null) && (!StringUtils.isEmpty(this.getTargetComponentId().extract(msg)))) {
-        try {
-          if (SendMode.single(this.getTargetSendMode())) {
-            getClusteredEventBus().send(getTargetComponentId().extract(msg), translatedMessage, getReplyService() != null);
-          } else {
-            getClusteredEventBus().publish(getTargetComponentId().extract(msg), translatedMessage);
-          }
-        } catch (InterlokException exception) {
-          throw new ServiceException("Cannot derive the target from the incoming message.", exception);
+        if (SendMode.single(this.getTargetSendMode())) {
+          getClusteredEventBus().send(getTargetComponentId().extract(msg), translatedMessage, getReplyService() != null);
+        } else {
+          getClusteredEventBus().publish(getTargetComponentId().extract(msg), translatedMessage);
         }
       } else {
         this.onVertxMessage(translatedMessage);
@@ -182,6 +189,8 @@ public class VertxService extends ServiceImp
   @Override
   protected void initService() throws CoreException {
     if (this.getVertXMessageTranslator() == null) this.setVertXMessageTranslator(new VertXMessageTranslator());
+    
+    this.setExecutorService(new ThreadPoolExecutor(1, maxThreads(), 1, TimeUnit.MINUTES, new LinkedBlockingQueue<>()));
     clusteredEventBus.setMessageCodec(getMessageCodec());
     LifecycleHelper.init(this.getService());
     LifecycleHelper.init(this.getReplyService());
@@ -215,6 +224,8 @@ public class VertxService extends ServiceImp
     LifecycleHelper.close(this.getService());
     LifecycleHelper.close(this.getReplyService());
     LifecycleHelper.close(this.getReplyServiceExceptionHandler());
+    
+    this.getExecutorService().shutdown();
   }
 
   public Service getService() {
@@ -259,8 +270,14 @@ public class VertxService extends ServiceImp
   
   @Override
   public void handle(Message<VertXMessage> event) {
-    VertXMessage vertXMessage = this.onVertxMessage(event.body());
-    event.reply(vertXMessage);
+    this.getExecutorService().submit(new Runnable() {
+      
+      @Override
+      public void run() {
+        VertXMessage vertXMessage = onVertxMessage(event.body());
+        event.reply(vertXMessage);
+      }
+    });
   }
 
   public VertXMessageTranslator getVertXMessageTranslator() {
@@ -346,5 +363,25 @@ public class VertxService extends ServiceImp
 
     public void handleProcessingException(AdaptrisMessage msg) {
     }
+  }
+
+  public ExecutorService getExecutorService() {
+    return executorService;
+  }
+
+  public void setExecutorService(ExecutorService executorService) {
+    this.executorService = executorService;
+  }
+  
+  protected int maxThreads() {
+    return NumberUtils.toIntDefaultIfNull(getMaxThreads(), DEFAULT_MAX_THREADS);
+  }
+
+  public Integer getMaxThreads() {
+    return maxThreads;
+  }
+
+  public void setMaxThreads(Integer maxThreads) {
+    this.maxThreads = maxThreads;
   }
 }

--- a/src/main/java/com/adaptris/vertx/VertxWorkflow.java
+++ b/src/main/java/com/adaptris/vertx/VertxWorkflow.java
@@ -6,6 +6,8 @@ import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 import javax.validation.Valid;
@@ -19,13 +21,13 @@ import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.CoreException;
-import com.adaptris.core.ProduceException;
 import com.adaptris.core.Service;
 import com.adaptris.core.ServiceException;
 import com.adaptris.core.StandardWorkflow;
 import com.adaptris.core.util.ManagedThreadFactory;
 import com.adaptris.interlok.InterlokException;
 import com.adaptris.interlok.config.DataInputParameter;
+import com.adaptris.util.NumberUtils;
 import com.adaptris.util.TimeInterval;
 import com.adaptris.vertx.util.BlockingExpiryQueue;
 import com.adaptris.vertx.util.ExpiryListener;
@@ -85,6 +87,8 @@ import io.vertx.core.eventbus.MessageCodec;
 public class VertxWorkflow extends StandardWorkflow
     implements Handler<Message<VertXMessage>>, ConsumerEventListener, ExpiryListener<VertXMessage> {
   
+  private static final int DEFAULT_MAX_THREADS = 10;
+  
   private static final TimeInterval DEFAULT_ITEM_EXPIRY = new TimeInterval(30L, TimeUnit.SECONDS);
   
   private static final int DEFAULT_QUEUE_SIZE = 10;
@@ -127,6 +131,10 @@ public class VertxWorkflow extends StandardWorkflow
   private transient Map<String, Map<Object, Object>> objectMetadataCache;
   
   private transient ConsumerLatch latch;
+  
+  private transient ExecutorService executorService;
+  
+  private Integer maxThreads;
 
   public VertxWorkflow() {
     super();
@@ -141,21 +149,21 @@ public class VertxWorkflow extends StandardWorkflow
   public void onAdaptrisMessage(AdaptrisMessage msg) {
     try {
       workflowStart(msg);
-      log.debug("start processing msg [{}]", msg.toString(false));      
+      log.debug("start processing msg [{}]", msg);      
       objectMetadataCache.put(msg.getUniqueId(), msg.getObjectHeaders()); 
       
       VertXMessage translatedMessage = getVertXMessageTranslator().translate(msg);
       translatedMessage.setServiceRecord(new ServiceRecord());
       translatedMessage.setStartProcessingTime(System.currentTimeMillis());
       
-      log.trace("New message [{}]::: Queue slots available: {}", msg.getUniqueId(), processingQueue.remainingCapacity());
-      processingQueue.put(translatedMessage);
+      log.trace("New message [{}]::: Queue slots available: {}", msg.getUniqueId(), getProcessingQueue().remainingCapacity());
+      getProcessingQueue().put(translatedMessage);
       
       // If we are expecting replies, lets block the consumer until we get some replies back.
       if (SendMode.single(getTargetSendMode())) {
         consumerQueue.put(translatedMessage);
       }
-      log.trace("New queue size : {}", processingQueue.remainingCapacity());
+      log.trace("New queue size : {}", getProcessingQueue().remainingCapacity());
       reportQueue("new message put [" + msg.getUniqueId() + "]");
     } catch (CoreException e) {
       log.error("Error processing message: ", e);
@@ -210,6 +218,8 @@ public class VertxWorkflow extends StandardWorkflow
     super.initialiseWorkflow();
     clusteredEventBus.setMessageCodec(getMessageCodec());
     
+    this.setExecutorService(new ThreadPoolExecutor(1, maxThreads(), 1, TimeUnit.MINUTES, new LinkedBlockingQueue<>()));
+    
     if (queueCapacity() <= 0) {
       throw new CoreException("Queue capacity must be greater than 0.");
     }
@@ -218,7 +228,7 @@ public class VertxWorkflow extends StandardWorkflow
       setVertXMessageTranslator(new VertXMessageTranslator());
     }
     
-    processingQueue = new ArrayBlockingQueue<>(queueCapacity(), true);
+    setProcessingQueue(new ArrayBlockingQueue<>(queueCapacity(), true));
     consumerQueue = new BlockingExpiryQueue<>(queueCapacity(), true);
     consumerQueue.setExpiryTimeout(itemExpiryTimeout());
     consumerQueue.registerExpiryListener(this);
@@ -229,11 +239,6 @@ public class VertxWorkflow extends StandardWorkflow
   @Override
   protected void prepareWorkflow() throws CoreException {
     super.prepareWorkflow();
-  }
-
-  @Override
-  protected void resubmitMessage(AdaptrisMessage msg) {
-    super.resubmitMessage(msg);
   }
 
   @Override
@@ -264,7 +269,7 @@ public class VertxWorkflow extends StandardWorkflow
   }
 
   void processQueuedMessage() throws InterruptedException {
-    VertXMessage xMessage = processingQueue.poll(1L, TimeUnit.SECONDS);
+    VertXMessage xMessage = getProcessingQueue().poll(1L, TimeUnit.SECONDS);
     
     if(xMessage != null) {
       reportQueue("after a get [" + xMessage.getAdaptrisMessage().getUniqueId() + "]");
@@ -312,9 +317,7 @@ public class VertxWorkflow extends StandardWorkflow
       try {
         doProduce(adaptrisMessage);
         logSuccess(adaptrisMessage, resultMessage.getStartProcessingTime());
-      } catch (ServiceException e) {
-        handleBadMessage("Exception from ServiceCollection", e, adaptrisMessage);
-      } catch (ProduceException e) {
+      } catch (Exception e) {
         adaptrisMessage.addEvent(getProducer(), false); // generate event
         handleBadMessage("Exception producing msg", e, adaptrisMessage);
         handleProduceException();
@@ -337,9 +340,13 @@ public class VertxWorkflow extends StandardWorkflow
 
   @Override
   public void handle(Message<VertXMessage> event) {
-    if(event.body() != null) {
-      onVertxMessage(event);
-    }
+    this.getExecutorService().submit(new Runnable() {
+      
+      @Override
+      public void run() {
+        onVertxMessage(event);
+      }
+    });
   }
   
   @Override
@@ -362,6 +369,8 @@ public class VertxWorkflow extends StandardWorkflow
   @Override
   protected void closeWorkflow() {
     super.closeWorkflow();
+    this.getExecutorService().shutdown();
+    
     if(messageExecutorHandle != null) {
       if(!messageExecutorHandle.isCancelled()) {
         messageExecutorHandle.cancel(true);
@@ -420,8 +429,8 @@ public class VertxWorkflow extends StandardWorkflow
       StringBuilder builder = new StringBuilder();
       builder.append("\nCurrent Queue State (" + title + "):\n");
 
-      VertXMessage[] array = new VertXMessage[processingQueue.size()];
-      array = (VertXMessage[]) processingQueue.toArray(array);
+      VertXMessage[] array = new VertXMessage[getProcessingQueue().size()];
+      array = (VertXMessage[]) getProcessingQueue().toArray(array);
       if (array != null) {
         for (VertXMessage message : array) {
           builder.append("\t" + message.getAdaptrisMessage().getUniqueId() + "\n");
@@ -485,6 +494,26 @@ public class VertxWorkflow extends StandardWorkflow
 
   TimeInterval itemExpiryTimeout() {
     return getItemExpiryTimeout() != null ? getItemExpiryTimeout() : DEFAULT_ITEM_EXPIRY;
+  }
+
+  public ExecutorService getExecutorService() {
+    return executorService;
+  }
+
+  public void setExecutorService(ExecutorService executorService) {
+    this.executorService = executorService;
+  }
+  
+  protected int maxThreads() {
+    return NumberUtils.toIntDefaultIfNull(getMaxThreads(), DEFAULT_MAX_THREADS);
+  }
+
+  public Integer getMaxThreads() {
+    return maxThreads;
+  }
+
+  public void setMaxThreads(Integer maxThreads) {
+    this.maxThreads = maxThreads;
   }
 
 }

--- a/src/main/java/com/adaptris/vertx/VertxWorkflow.java
+++ b/src/main/java/com/adaptris/vertx/VertxWorkflow.java
@@ -369,7 +369,7 @@ public class VertxWorkflow extends StandardWorkflow
   @Override
   protected void closeWorkflow() {
     super.closeWorkflow();
-    this.getExecutorService().shutdown();
+    ManagedThreadFactory.shutdownQuietly(this.getExecutorService(), 30000l);
     
     if(messageExecutorHandle != null) {
       if(!messageExecutorHandle.isCancelled()) {
@@ -496,11 +496,11 @@ public class VertxWorkflow extends StandardWorkflow
     return getItemExpiryTimeout() != null ? getItemExpiryTimeout() : DEFAULT_ITEM_EXPIRY;
   }
 
-  public ExecutorService getExecutorService() {
+  ExecutorService getExecutorService() {
     return executorService;
   }
 
-  public void setExecutorService(ExecutorService executorService) {
+  void setExecutorService(ExecutorService executorService) {
     this.executorService = executorService;
   }
   

--- a/src/test/java/com/adaptris/vertx/VertxWorkflowTest.java
+++ b/src/test/java/com/adaptris/vertx/VertxWorkflowTest.java
@@ -172,6 +172,19 @@ public class VertxWorkflowTest extends ExampleWorkflowCase {
     verify(mockVertxMessage).reply(vertXMessage);
   }
   
+  public void testReceivedHandleVertxMessage() throws Exception {
+    AdaptrisMessage adaptrisMessage = DefaultMessageFactory.getDefaultInstance().newMessage();
+    VertXMessage vertXMessage = new VertXMessageTranslator().translate(adaptrisMessage);
+    
+    when(mockVertxMessage.body())
+        .thenReturn(vertXMessage);
+    
+    vertxWorkflow.handle(mockVertxMessage);
+    
+    Thread.sleep(500l);
+    verify(mockVertxMessage).reply(vertXMessage);
+  }
+  
   public void testReceivedVertxMessageFailsTranslate() throws Exception {
     AdaptrisMessage adaptrisMessage = DefaultMessageFactory.getDefaultInstance().newMessage();
     VertXMessage vertXMessage = new VertXMessageTranslator().translate(adaptrisMessage);


### PR DESCRIPTION
We no longer process each service in the Vertx kernel thread; instead we create our own for each message received.

Added Awaitility for test compile.