### PR TITLE
INTERLOK-3403 Upgrade to mockito 3.7.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -132,7 +132,8 @@ dependencies {
   umlDoclet("nl.talsmasoftware:umldoclet:1.1.4")
 
   testCompile ("junit:junit:$junitVersion")
-  testCompile ("org.mockito:mockito-all:1.10.19")
+  testCompile ("org.mockito:mockito-core:3.7.0")
+  testCompile ("org.mockito:mockito-inline:3.7.0")
   testCompile ('org.awaitility:awaitility:4.0.3')
   testCompile "org.slf4j:slf4j-simple:$slf4jVersion"
   // exclude any log4j dependencies so that we can just use slf4j simple.

--- a/src/test/java/com/adaptris/vertx/VertxServiceTest.java
+++ b/src/test/java/com/adaptris/vertx/VertxServiceTest.java
@@ -2,8 +2,8 @@ package com.adaptris.vertx;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
@@ -24,7 +24,6 @@ import com.adaptris.core.CoreException;
 import com.adaptris.core.DefaultMessageFactory;
 import com.adaptris.core.ProcessingExceptionHandler;
 import com.adaptris.core.Service;
-import com.adaptris.core.ServiceCase;
 import com.adaptris.core.ServiceException;
 import com.adaptris.core.StandardProcessingExceptionHandler;
 import com.adaptris.core.common.ConstantDataInputParameter;
@@ -32,17 +31,18 @@ import com.adaptris.core.services.LogMessageService;
 import com.adaptris.core.util.LifecycleHelper;
 import com.adaptris.interlok.InterlokException;
 import com.adaptris.interlok.config.DataInputParameter;
+import com.adaptris.interlok.junit.scaffolding.services.ExampleServiceCase;
 
 import io.vertx.core.eventbus.Message;
 
-public class VertxServiceTest extends ServiceCase {
-  
+public class VertxServiceTest extends ExampleServiceCase {
+
   public static final String BASE_DIR_KEY = "ServiceCase.baseDir";
 
   private VertxService vertxService;
-  
+
   private ConstantDataInputParameter targetComponentId;
-  
+
   @Mock
   private ClusteredEventBus mockClusteredEventBus;
   @Mock
@@ -59,11 +59,13 @@ public class VertxServiceTest extends ServiceCase {
   private ProcessingExceptionHandler mockProcessingExceptionHandler;
   @Mock
   private DataInputParameter<String> mockDataInputParameter;
-  
+
+  private AutoCloseable closeable;
+
   @Before
   public void setUp() throws Exception {
-    MockitoAnnotations.initMocks(this);
-    
+    closeable = MockitoAnnotations.openMocks(this);
+
     vertxService = new VertxService();
     vertxService.setService(wrappedService);
     vertxService.setReplyService(replyService);
@@ -73,6 +75,7 @@ public class VertxServiceTest extends ServiceCase {
     vertxService.setVertxProperties(null);
     // INTERLOK-1563 need to invoke the consumerStarted() method, to handle the countdownLatch
     doAnswer(new Answer<Object>() {
+      @Override
       public Object answer(InvocationOnMock invocation) {
         ((ConsumerEventListener) invocation.getArguments()[0]).consumerStarted();
         return null;
@@ -81,48 +84,44 @@ public class VertxServiceTest extends ServiceCase {
 
     targetComponentId = new ConstantDataInputParameter("SomeWorkflowID");
     vertxService.setTargetComponentId(targetComponentId);
-    
+
     LifecycleHelper.initAndStart(vertxService);
   }
-  
+
   @After
   public void tearDown() throws Exception {
     LifecycleHelper.stopAndClose(vertxService);
-  }
-  
-  @Override
-  public boolean isAnnotatedForJunit4() {
-    return true;
+    closeable.close();
   }
 
   @Test
   public void testDoServiceSend() throws Exception {
     AdaptrisMessage adaptrisMessage = DefaultMessageFactory.getDefaultInstance().newMessage();
-    
+
     vertxService.doService(adaptrisMessage);
-    
+
     verify(mockClusteredEventBus).send(any(), any(), anyBoolean());
   }
-  
+
   @Test
   public void testDoServicePublish() throws Exception {
     AdaptrisMessage adaptrisMessage = DefaultMessageFactory.getDefaultInstance().newMessage();
-    
+
     vertxService.setTargetSendMode(SendMode.Mode.ALL);
     vertxService.doService(adaptrisMessage);
-    
+
     verify(mockClusteredEventBus).publish(any(), any());
   }
-  
+
   @Test
   public void testDoServiceTranslateFails() throws Exception {
     AdaptrisMessage adaptrisMessage = DefaultMessageFactory.getDefaultInstance().newMessage();
-    
+
     when(mockTranslator.translate(adaptrisMessage))
-        .thenThrow(new CoreException("GeneratedException"));
-    
+    .thenThrow(new CoreException("GeneratedException"));
+
     vertxService.setVertXMessageTranslator(mockTranslator);
-    
+
     try {
       vertxService.doService(adaptrisMessage);
       fail("Exception expected");
@@ -130,16 +129,16 @@ public class VertxServiceTest extends ServiceCase {
       // expected
     }
   }
-  
+
   @Test
   public void testDoServiceTargetFails() throws Exception {
     AdaptrisMessage adaptrisMessage = DefaultMessageFactory.getDefaultInstance().newMessage();
-    
+
     doThrow(new InterlokException("expected"))
-        .when(mockDataInputParameter).extract(adaptrisMessage);
-    
+    .when(mockDataInputParameter).extract(adaptrisMessage);
+
     vertxService.setTargetComponentId(mockDataInputParameter);
-    
+
     try {
       vertxService.doService(adaptrisMessage);
       fail("Exception expected");
@@ -147,100 +146,100 @@ public class VertxServiceTest extends ServiceCase {
       // expected
     }
   }
-  
+
   @Test
   public void testDoServiceNoSendEndpoint() throws Exception {
     AdaptrisMessage adaptrisMessage = DefaultMessageFactory.getDefaultInstance().newMessage();
-    
+
     vertxService.setTargetComponentId(new ConstantDataInputParameter(""));
 
     vertxService.doService(adaptrisMessage);
-    
+
     verify(wrappedService).doService(any(AdaptrisMessage.class));
 
   }
-  
+
   @Test
   public void testReceiveMessageServiceFails() throws Exception {
     AdaptrisMessage adaptrisMessage = DefaultMessageFactory.getDefaultInstance().newMessage();
     VertXMessage vertXMessage = new VertXMessageTranslator().translate(adaptrisMessage);
-    
+
     when(mockVertxMessage.body())
-        .thenReturn(vertXMessage);
-    
+    .thenReturn(vertXMessage);
+
     doThrow(new ServiceException("Generated Exception"))
-        .when(wrappedService).doService(any(AdaptrisMessage.class));
+    .when(wrappedService).doService(any(AdaptrisMessage.class));
 
     vertxService.handle(mockVertxMessage);
-    
+
     Awaitility.await().until(() -> vertXMessage.getServiceRecord().getServices().size() > 0);
-    
+
     assertEquals(ServiceState.ERROR, vertXMessage.getServiceRecord().getServices().get(0).getState());
   }
-  
+
   @Test
   public void testReceiveMessageTranslateFails() throws Exception {
     AdaptrisMessage adaptrisMessage = DefaultMessageFactory.getDefaultInstance().newMessage();
     VertXMessage vertXMessage = new VertXMessageTranslator().translate(adaptrisMessage);
-    
+
     when(mockVertxMessage.body())
-        .thenReturn(vertXMessage);
-    
+    .thenReturn(vertXMessage);
+
     when(mockTranslator.translate(vertXMessage))
-        .thenThrow(new CoreException("GeneratedException"));
+    .thenThrow(new CoreException("GeneratedException"));
 
     vertxService.setVertXMessageTranslator(mockTranslator);
 
     vertxService.handle(mockVertxMessage);
-    
+
     verify(wrappedService, never()).doService(any(AdaptrisMessage.class));
   }
-  
+
   @Test
   public void testReceiveReplyMessageTranslateFails() throws Exception {
     AdaptrisMessage adaptrisMessage = DefaultMessageFactory.getDefaultInstance().newMessage();
     VertXMessage vertXMessage = new VertXMessageTranslator().translate(adaptrisMessage);
-    
+
     when(mockVertxReplyMessage.body())
-        .thenReturn(vertXMessage);
-    
+    .thenReturn(vertXMessage);
+
     when(mockTranslator.translate(vertXMessage))
-        .thenThrow(new CoreException("GeneratedException"));
+    .thenThrow(new CoreException("GeneratedException"));
 
     vertxService.setVertXMessageTranslator(mockTranslator);
 
     vertxService.handleMessageReply(mockVertxReplyMessage);
-    
+
     verify(replyService, never()).doService(any(AdaptrisMessage.class));
   }
-  
+
   @Test
   public void testReceiveReplyMessageRunsReplyService() throws Exception {
     AdaptrisMessage adaptrisMessage = DefaultMessageFactory.getDefaultInstance().newMessage();
     VertXMessage vertXMessage = new VertXMessageTranslator().translate(adaptrisMessage);
-    
+
     when(mockVertxReplyMessage.body())
-        .thenReturn(vertXMessage);
+    .thenReturn(vertXMessage);
 
     vertxService.handleMessageReply(mockVertxReplyMessage);
-    
+
     verify(replyService).doService(any(AdaptrisMessage.class));
   }
-  
+
   @Test
   public void testReceiveReplyMessageRunsReplyServiceFails() throws Exception {
     AdaptrisMessage adaptrisMessage = DefaultMessageFactory.getDefaultInstance().newMessage();
     VertXMessage vertXMessage = new VertXMessageTranslator().translate(adaptrisMessage);
-    
+
     vertxService.setReplyServiceExceptionHandler(mockProcessingExceptionHandler);
-    
+
     when(mockVertxReplyMessage.body())
-        .thenReturn(vertXMessage);
+    .thenReturn(vertXMessage);
     doThrow(new ServiceException("GeneratedException"))
-        .when(replyService).doService(any(AdaptrisMessage.class));
+    .when(replyService).doService(any(AdaptrisMessage.class));
 
     vertxService.handleMessageReply(mockVertxReplyMessage);
-    
+
     verify(replyService).doService(any(AdaptrisMessage.class));
     verify(mockProcessingExceptionHandler).handleProcessingException(any(AdaptrisMessage.class));
   }
@@ -253,7 +252,7 @@ public class VertxServiceTest extends ServiceCase {
     vertxService.setReplyService(new LogMessageService());
     vertxService.setReplyServiceExceptionHandler(new StandardProcessingExceptionHandler(new LogMessageService()));
     vertxService.setTargetComponentId(new ConstantDataInputParameter("my-cluster-name"));
-    
+
     return vertxService;
   }
 }

--- a/src/test/java/com/adaptris/vertx/VertxWorkflowTest.java
+++ b/src/test/java/com/adaptris/vertx/VertxWorkflowTest.java
@@ -2,8 +2,8 @@ package com.adaptris.vertx;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
@@ -26,7 +26,6 @@ import com.adaptris.core.AdaptrisMessageProducerImp;
 import com.adaptris.core.Channel;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.DefaultMessageFactory;
-import com.adaptris.core.ExampleWorkflowCase;
 import com.adaptris.core.ProcessingExceptionHandler;
 import com.adaptris.core.ProduceException;
 import com.adaptris.core.Service;
@@ -38,22 +37,22 @@ import com.adaptris.core.stubs.MockChannel;
 import com.adaptris.core.stubs.MockNonStandardRequestReplyProducer;
 import com.adaptris.core.util.LifecycleHelper;
 import com.adaptris.interlok.InterlokException;
+import com.adaptris.interlok.junit.scaffolding.ExampleWorkflowCase;
 import com.adaptris.interlok.types.InterlokMessage;
 import com.adaptris.util.TimeInterval;
 
-import io.vertx.core.eventbus.EventBus;
 import io.vertx.core.eventbus.Message;
 
 public class VertxWorkflowTest extends ExampleWorkflowCase {
-  
+
   public static final String BASE_DIR_KEY = "WorkflowCase.baseDir";
 
   private VertxWorkflow vertxWorkflow;
-  
+
   private ConstantDataInputParameter targetWorkflowId;
-  
+
   private Channel channel;
-  
+
   @Mock
   private ConstantDataInputParameter mockTargetWorkflowId;
   @Mock
@@ -69,52 +68,49 @@ public class VertxWorkflowTest extends ExampleWorkflowCase {
   @Mock
   private Service mockService1, mockService2;
   @Mock
-  private EventBus mockEventBus;
-  @Mock
   private AdaptrisMessageProducerImp mockProducer;
   @Mock
   private ArrayBlockingQueue<VertXMessage> mockInternalprocessingQueue;
-  
+
+  private AutoCloseable closeable;
+
   @After
   public void tearDown() throws Exception {
     LifecycleHelper.stopAndClose(channel);
+    closeable.close();
   }
-  
+
   @Before
   public void setUp() throws Exception {
-    MockitoAnnotations.initMocks(this);
-    
+    closeable = MockitoAnnotations.openMocks(this);
+
     channel = new MockChannel();
-    
+
     vertxWorkflow = new VertxWorkflow();
     targetWorkflowId = new ConstantDataInputParameter("SomeWorkflowID");
-    
-    vertxWorkflow.setTargetComponentId(targetWorkflowId);    
+
+    vertxWorkflow.setTargetComponentId(targetWorkflowId);
     vertxWorkflow.setProducer(mockProducer);
     vertxWorkflow.setClusteredEventBus(mockClusteredEventBus);
     vertxWorkflow.setMaxThreads(5);
     vertxWorkflow.setVertxProperties(null);
     // INTERLOK-1563 need to invoke the consumerStarted() method, to handle the countdownLatch
     doAnswer(new Answer<Object>() {
+      @Override
       public Object answer(InvocationOnMock invocation) {
         ((ConsumerEventListener) invocation.getArguments()[0]).consumerStarted();
         return null;
       }
     }).when(mockClusteredEventBus).startClusteredConsumer(vertxWorkflow, null);
-    
+
     channel.getWorkflowList().add(vertxWorkflow);
     LifecycleHelper.initAndStart(channel);
   }
-  
-  @Override
-  public boolean isAnnotatedForJunit4() {
-    return true;
-  }
-  
+
   @Test
   public void testInitWithNegativeQueueCapacity() throws Exception {
     vertxWorkflow.setQueueCapacity(-1);
-    
+
     try {
       vertxWorkflow.initialiseWorkflow();
       fail("Expect a core exception, with a negative queue capacity");
@@ -122,344 +118,332 @@ public class VertxWorkflowTest extends ExampleWorkflowCase {
       // expected
     }
   }
-  
+
   @Test
   public void testOnMessageInterrupted() throws Exception {
     AdaptrisMessage adaptrisMessage = DefaultMessageFactory.getDefaultInstance().newMessage();
-    
+
     doThrow(new InterruptedException("GeneratedExpected"))
-        .when(mockInternalprocessingQueue).put(any(VertXMessage.class));
-    
+    .when(mockInternalprocessingQueue).put(any(VertXMessage.class));
+
     vertxWorkflow.setProcessingQueue(mockInternalprocessingQueue);
     vertxWorkflow.registerActiveMsgErrorHandler(mockErrorHandler);
-    
+
     vertxWorkflow.onAdaptrisMessage(adaptrisMessage);
-    
+
     verify(mockErrorHandler).handleProcessingException(any(AdaptrisMessage.class));
   }
-  
+
   @Test
   public void testOnMessageSendToCluster() throws Exception {
     AdaptrisMessage adaptrisMessage = DefaultMessageFactory.getDefaultInstance().newMessage();
-    
+
     vertxWorkflow.onAdaptrisMessage(adaptrisMessage);
   }
-  
+
   @Test
   public void testOnMessageCannotTranslateMessage() throws Exception {
     AdaptrisMessage adaptrisMessage = DefaultMessageFactory.getDefaultInstance().newMessage();
-    
+
     vertxWorkflow.registerActiveMsgErrorHandler(mockErrorHandler);
-    
+
     vertxWorkflow.setVertXMessageTranslator(mockTranslator);
     when(mockTranslator.translate(adaptrisMessage))
-        .thenThrow(new CoreException("GeneratedException"));
-    
+    .thenThrow(new CoreException("GeneratedException"));
+
     vertxWorkflow.onAdaptrisMessage(adaptrisMessage);
-    
+
     verify(mockErrorHandler).handleProcessingException(adaptrisMessage);
   }
-  
+
   @Test
   public void testOnMessageInterruptedException() throws Exception {
     AdaptrisMessage adaptrisMessage = DefaultMessageFactory.getDefaultInstance().newMessage();
-    
+
     vertxWorkflow.registerActiveMsgErrorHandler(mockErrorHandler);
     vertxWorkflow.setProcessingQueue(mockInternalprocessingQueue);
-    
+
     doThrow(new InterruptedException("GeneratedException"))
-        .when(mockInternalprocessingQueue).put(any(VertXMessage.class));
-    
+    .when(mockInternalprocessingQueue).put(any(VertXMessage.class));
+
     vertxWorkflow.onAdaptrisMessage(adaptrisMessage);
-    
+
     verify(mockErrorHandler).handleProcessingException(adaptrisMessage);
   }
-  
+
   @Test
   public void testReceivedVertxMessage() throws Exception {
     AdaptrisMessage adaptrisMessage = DefaultMessageFactory.getDefaultInstance().newMessage();
     VertXMessage vertXMessage = new VertXMessageTranslator().translate(adaptrisMessage);
-    
+
     when(mockVertxMessage.body())
-        .thenReturn(vertXMessage);
-    
+    .thenReturn(vertXMessage);
+
     vertxWorkflow.onVertxMessage(mockVertxMessage);
-    
+
     verify(mockVertxMessage).reply(vertXMessage);
   }
-  
+
   @Test
   public void testReceivedHandleVertxMessage() throws Exception {
     AdaptrisMessage adaptrisMessage = DefaultMessageFactory.getDefaultInstance().newMessage();
     VertXMessage vertXMessage = new VertXMessageTranslator().translate(adaptrisMessage);
-    
+
     when(mockVertxMessage.body())
-        .thenReturn(vertXMessage);
-    
+    .thenReturn(vertXMessage);
+
     vertxWorkflow.handle(mockVertxMessage);
-    
+
     Thread.sleep(500l);
     verify(mockVertxMessage).reply(vertXMessage);
   }
-  
+
   @Test
   public void testReceivedVertxMessageFailsTranslate() throws Exception {
     AdaptrisMessage adaptrisMessage = DefaultMessageFactory.getDefaultInstance().newMessage();
     VertXMessage vertXMessage = new VertXMessageTranslator().translate(adaptrisMessage);
-    
+
     vertxWorkflow.setVertXMessageTranslator(mockTranslator);
-    
+
     when(mockVertxMessage.body())
-        .thenReturn(vertXMessage);
+    .thenReturn(vertXMessage);
     when(mockTranslator.translate(vertXMessage))
-      .thenThrow(new CoreException("GeneratedException"));
-    
+    .thenThrow(new CoreException("GeneratedException"));
+
     vertxWorkflow.onVertxMessage(mockVertxMessage);
-    
+
     verify(mockVertxMessage, never()).reply(vertXMessage);
   }
-  
+
   @Test
   public void testReceivedVertxMessageFailsTranslateWhenReplying() throws Exception {
     AdaptrisMessage adaptrisMessage = DefaultMessageFactory.getDefaultInstance().newMessage();
     VertXMessage vertXMessage = new VertXMessageTranslator().translate(adaptrisMessage);
-    
+
     vertxWorkflow.setVertXMessageTranslator(mockTranslator);
-    
+
     when(mockVertxMessage.body())
-        .thenReturn(vertXMessage);
+    .thenReturn(vertXMessage);
     when(mockTranslator.translate(vertXMessage))
-        .thenReturn(adaptrisMessage);
+    .thenReturn(adaptrisMessage);
     when(mockTranslator.translate(any(AdaptrisMessage.class)))
-      .thenThrow(new CoreException("GeneratedException"));
-    
+    .thenThrow(new CoreException("GeneratedException"));
+
     vertxWorkflow.onVertxMessage(mockVertxMessage);
-    
+
     verify(mockVertxMessage, never()).reply(vertXMessage);
   }
-  
+
   @Test
   public void testReceivedVertxMessageRunsServices() throws Exception {
     AdaptrisMessage adaptrisMessage = DefaultMessageFactory.getDefaultInstance().newMessage();
     VertXMessage vertXMessage = new VertXMessageTranslator().translate(adaptrisMessage);
-    
+
     when(mockVertxMessage.body())
-        .thenReturn(vertXMessage);
-    
+    .thenReturn(vertXMessage);
+
     vertxWorkflow.getServiceCollection().add(mockService1);
     vertxWorkflow.getServiceCollection().add(mockService2);
-    
+
     vertxWorkflow.onVertxMessage(mockVertxMessage);
-    
+
     verify(mockService1).doService(any());
     verify(mockService2).doService(any());
     verify(mockVertxMessage).reply(vertXMessage);
   }
-  
+
   @Test
   public void testReceivedVertxMessageRunsServicesFirstServiceError() throws Exception {
     AdaptrisMessage adaptrisMessage = DefaultMessageFactory.getDefaultInstance().newMessage();
     VertXMessage vertXMessage = new VertXMessageTranslator().translate(adaptrisMessage);
-    
+
     when(mockVertxMessage.body())
-        .thenReturn(vertXMessage);
-    
+    .thenReturn(vertXMessage);
+
     doThrow(new ServiceException("GeneratedException"))
-        .when(mockService1).doService(any());
-    
+    .when(mockService1).doService(any());
+
     vertxWorkflow.getServiceCollection().add(mockService1);
     vertxWorkflow.getServiceCollection().add(mockService2);
-    
+
     vertxWorkflow.onVertxMessage(mockVertxMessage);
-    
+
     verify(mockService1).doService(any());
     verify(mockService2, never()).doService(any());
     verify(mockVertxMessage).reply(vertXMessage);
   }
-  
+
   @Test
   public void testReceivedVertxMessageRunsServicesFirstServiceErrorContinueOnError() throws Exception {
     AdaptrisMessage adaptrisMessage = DefaultMessageFactory.getDefaultInstance().newMessage();
     VertXMessage vertXMessage = new VertXMessageTranslator().translate(adaptrisMessage);
-    
+
     when(mockVertxMessage.body())
-        .thenReturn(vertXMessage);
-    
+    .thenReturn(vertXMessage);
+
     doThrow(new ServiceException("GeneratedException"))
-        .when(mockService1).doService(any());
-    
+    .when(mockService1).doService(any());
+
     vertxWorkflow.getServiceCollection().add(mockService1);
     vertxWorkflow.getServiceCollection().add(mockService2);
-    
+
     vertxWorkflow.setContinueOnError(true);
-    
+
     vertxWorkflow.onVertxMessage(mockVertxMessage);
-    
+
     verify(mockService1).doService(any());
     verify(mockService2).doService(any());
     verify(mockVertxMessage).reply(vertXMessage);
   }
-  
+
   @Test
   public void testOnMessageTargetFails() throws Exception {
     AdaptrisMessage adaptrisMessage = DefaultMessageFactory.getDefaultInstance().newMessage();
     VertXMessage vertXMessage = new VertXMessageTranslator().translate(adaptrisMessage);
-    
+
     ArrayBlockingQueue<VertXMessage> internalprocessingQueue = new ArrayBlockingQueue<>(1);
     internalprocessingQueue.put(vertXMessage);
-    
+
     vertxWorkflow.registerActiveMsgErrorHandler(mockErrorHandler);
     vertxWorkflow.setProcessingQueue(internalprocessingQueue);
-    vertxWorkflow.getClusteredEventBus().setEventBus(mockEventBus);
     vertxWorkflow.setTargetComponentId(mockTargetWorkflowId);
-    
+
     when(mockTargetWorkflowId.extract(any(InterlokMessage.class)))
-        .thenThrow(new InterlokException("GeneratedException"));
-    
-    try {
-      vertxWorkflow.processQueuedMessage();
-    } catch (Exception ex) {
-    } finally {
-      verify(mockErrorHandler).handleProcessingException(any(AdaptrisMessage.class));
-    }
+    .thenThrow(new InterlokException("GeneratedException"));
+
+    vertxWorkflow.processQueuedMessage();
+
+    verify(mockErrorHandler).handleProcessingException(any(AdaptrisMessage.class));
   }
-  
+
   @Test
   public void testOnMessageSendToSingle() throws Exception {
     AdaptrisMessage adaptrisMessage = DefaultMessageFactory.getDefaultInstance().newMessage();
     VertXMessage vertXMessage = new VertXMessageTranslator().translate(adaptrisMessage);
-    
+
     ArrayBlockingQueue<VertXMessage> internalprocessingQueue = new ArrayBlockingQueue<>(1);
     internalprocessingQueue.put(vertXMessage);
-    
+
     vertxWorkflow.setProcessingQueue(internalprocessingQueue);
-    vertxWorkflow.getClusteredEventBus().setEventBus(mockEventBus);
-    
-    try {
-      vertxWorkflow.processQueuedMessage();
-    } catch (Exception ex) {
-    } finally {
-      verify(mockClusteredEventBus).send(any(), any(), anyBoolean());
-    }
+
+    vertxWorkflow.processQueuedMessage();
+
+    verify(mockClusteredEventBus).send(any(), any(), anyBoolean());
   }
-  
+
   @Test
   public void testOnMessageSendToAll() throws Exception {
     AdaptrisMessage adaptrisMessage = DefaultMessageFactory.getDefaultInstance().newMessage();
     VertXMessage vertXMessage = new VertXMessageTranslator().translate(adaptrisMessage);
-    
+
     ArrayBlockingQueue<VertXMessage> internalprocessingQueue = new ArrayBlockingQueue<>(1);
     internalprocessingQueue.put(vertXMessage);
-    
+
     vertxWorkflow.setTargetSendMode(SendMode.Mode.ALL);
     vertxWorkflow.setProcessingQueue(internalprocessingQueue);
-    vertxWorkflow.getClusteredEventBus().setEventBus(mockEventBus);
-    
-    try {
-      vertxWorkflow.processQueuedMessage();
-    } catch (Exception ex) {
-    } finally {
-      verify(mockClusteredEventBus).publish(any(), any());
-    }
+
+    vertxWorkflow.processQueuedMessage();
+
+    verify(mockClusteredEventBus).publish(any(), any());
   }
-  
+
   @Test
   public void testHandleMessageReplyFailsTranslator() throws Exception {
     AdaptrisMessage adaptrisMessage = DefaultMessageFactory.getDefaultInstance().newMessage();
     VertXMessage vertXMessage = new VertXMessageTranslator().translate(adaptrisMessage);
-    
+
     vertxWorkflow.registerActiveMsgErrorHandler(mockErrorHandler);
     vertxWorkflow.setVertXMessageTranslator(mockTranslator);
-    
+
     when(mockReplyVertxMessage.body())
-        .thenReturn(vertXMessage);
+    .thenReturn(vertXMessage);
     when(mockTranslator.translate(vertXMessage))
-        .thenThrow(new CoreException("GeneratedException"));
-    
+    .thenThrow(new CoreException("GeneratedException"));
+
     vertxWorkflow.handleMessageReply(mockReplyVertxMessage);
-    
+
     verify(mockProducer, never()).produce(adaptrisMessage);
   }
-  
+
   @Test
   public void testHandleMessageReplyHasErrors() throws Exception {
     AdaptrisMessage adaptrisMessage = DefaultMessageFactory.getDefaultInstance().newMessage();
     VertXMessage vertXMessage = new VertXMessageTranslator().translate(adaptrisMessage);
     vertXMessage.getServiceRecord().addService(new InterlokService("SomeId", ServiceState.ERROR));
-    
+
     vertxWorkflow.registerActiveMsgErrorHandler(mockErrorHandler);
-    
+
     when(mockReplyVertxMessage.body())
-        .thenReturn(vertXMessage);
-    
+    .thenReturn(vertXMessage);
+
     vertxWorkflow.handleMessageReply(mockReplyVertxMessage);
-    
+
     verify(mockErrorHandler).handleProcessingException(any(AdaptrisMessage.class));
   }
-  
+
   @Test
   public void testHandleMessageReplyDoesProduce() throws Exception {
     AdaptrisMessage adaptrisMessage = DefaultMessageFactory.getDefaultInstance().newMessage();
     VertXMessage vertXMessage = new VertXMessageTranslator().translate(adaptrisMessage);
     vertXMessage.getServiceRecord().addService(new InterlokService("SomeId", ServiceState.COMPLETE));
-        
+
     when(mockReplyVertxMessage.body())
-        .thenReturn(vertXMessage);
+    .thenReturn(vertXMessage);
     when(mockProducer.createName())
-        .thenReturn("name");
-    
+    .thenReturn("name");
+
     vertxWorkflow.handleMessageReply(mockReplyVertxMessage);
-    
+
     verify(mockProducer).produce(any(AdaptrisMessage.class));
   }
-  
+
   @Test
   public void testHandleMessageReplyProduceFails() throws Exception {
     AdaptrisMessage adaptrisMessage = DefaultMessageFactory.getDefaultInstance().newMessage();
     VertXMessage vertXMessage = new VertXMessageTranslator().translate(adaptrisMessage);
     vertXMessage.getServiceRecord().addService(new InterlokService("SomeId", ServiceState.COMPLETE));
-        
+
     vertxWorkflow.registerActiveMsgErrorHandler(mockErrorHandler);
-    
+
     when(mockReplyVertxMessage.body())
-        .thenReturn(vertXMessage);
+    .thenReturn(vertXMessage);
     when(mockProducer.createName())
-        .thenReturn("name");
+    .thenReturn("name");
     doThrow(new ProduceException("Generated Exception"))
-        .when(mockProducer).produce(any(AdaptrisMessage.class));
-    
+    .when(mockProducer).produce(any(AdaptrisMessage.class));
+
     vertxWorkflow.handleMessageReply(mockReplyVertxMessage);
-    
+
     verify(mockProducer).produce(any(AdaptrisMessage.class));
     verify(mockErrorHandler).handleProcessingException(any(AdaptrisMessage.class));
   }
-  
+
   @Test
   public void testObjectMetadataCopy() throws Exception {
     AdaptrisMessage adaptrisMessage = DefaultMessageFactory.getDefaultInstance().newMessage();
     adaptrisMessage.addObjectHeader("ObjectHeaderKey", "ObjectHeaderValue");
-    
+
     MockNonStandardRequestReplyProducer producer = new MockNonStandardRequestReplyProducer();
     vertxWorkflow.setProducer(producer);
-    
+
     vertxWorkflow.setProcessingQueue(mockInternalprocessingQueue);
-    
+
     vertxWorkflow.onAdaptrisMessage(adaptrisMessage);
-    
+
     VertXMessage vertXMessage = new VertXMessageTranslator().translate(adaptrisMessage);
     vertXMessage.getServiceRecord().addService(new InterlokService("SomeId", ServiceState.COMPLETE));
-        
+
     when(mockReplyVertxMessage.body())
-        .thenReturn(vertXMessage);
+    .thenReturn(vertXMessage);
     when(mockProducer.createName())
-        .thenReturn("name");
-    
+    .thenReturn("name");
+
     vertxWorkflow.handleMessageReply(mockReplyVertxMessage);
-    
+
     AdaptrisMessage message = (AdaptrisMessage) producer.getProducedMessages().get(0);
-    assertEquals("ObjectHeaderValue", (String) message.getObjectHeaders().get("ObjectHeaderKey"));
+    assertEquals("ObjectHeaderValue", message.getObjectHeaders().get("ObjectHeaderKey"));
   }
-  
+
   @Override
   protected WorkflowImp createWorkflowForGenericTests() throws Exception {
     VertxWorkflow workflow = new VertxWorkflow();
@@ -478,7 +462,7 @@ public class VertxWorkflowTest extends ExampleWorkflowCase {
     workflow.setTargetComponentId(new ConstantDataInputParameter("my-cluster-name"));
     workflow.getServiceCollection().add(new LogMessageService());
     workflow.setItemExpiryTimeout(new TimeInterval(30L, TimeUnit.SECONDS));
-    
+
     channel.getWorkflowList().add(workflow);
     return channel;
   }

--- a/src/test/java/com/adaptris/vertx/util/BlockingExpiryQueueTest.java
+++ b/src/test/java/com/adaptris/vertx/util/BlockingExpiryQueueTest.java
@@ -17,51 +17,53 @@ import org.mockito.MockitoAnnotations;
 import com.adaptris.util.TimeInterval;
 
 public class BlockingExpiryQueueTest {
-  
+
   private BlockingExpiryQueue<String> blockingExpiryQueue;
-  
+
   @Mock
   private ExpiryListener<String> mockExpiryListener;
-  
+
+  private AutoCloseable closeable;
+
   @Before
   public void setUp() throws Exception {
-    MockitoAnnotations.initMocks(this);
+    closeable = MockitoAnnotations.openMocks(this);
     blockingExpiryQueue = new BlockingExpiryQueue<>(3);
     blockingExpiryQueue.registerExpiryListener(mockExpiryListener);
     blockingExpiryQueue.setExpiryTimeout(new TimeInterval(100L, TimeUnit.MILLISECONDS));
   }
-  
+
   @After
   public void tearDown() throws Exception {
-    
+    closeable.close();
   }
-  
+
   @Test
   public void testPutAndRetrieve() throws Exception {
     blockingExpiryQueue.put("1");
     blockingExpiryQueue.put("2");
     blockingExpiryQueue.put("3");
-    
+
     assertEquals("1", blockingExpiryQueue.take());
     assertEquals("2", blockingExpiryQueue.take());
     assertEquals("3", blockingExpiryQueue.take());
-    
+
     assertNull(blockingExpiryQueue.poll(1L, TimeUnit.SECONDS));
-    
+
     verify(mockExpiryListener, never()).itemExpired("1");
   }
-  
+
   @Test
   public void testExpireHead() throws Exception {
     blockingExpiryQueue.put("1");
     blockingExpiryQueue.put("2");
     blockingExpiryQueue.put("3");
     blockingExpiryQueue.put("4"); // this will expire the first item
-    
+
     assertEquals("2", blockingExpiryQueue.take());
     assertEquals("3", blockingExpiryQueue.take());
     assertEquals("4", blockingExpiryQueue.take());
-    
+
     verify(mockExpiryListener, times(1)).itemExpired("1");
   }
 


### PR DESCRIPTION
## Motivation

We want to upgrade all optional components to use the latest version of mockito

## Modification

- Upgrade to mockito 3.7.0
- Use mockito 3 ArgumentMatchers
- Remove the mock EventBus in VertxWorkflowTest as it fails to be mocked and it is only used by the ClusterEventBus mock

## Result

Upgrade done

## Testing

`gradlew check` should work.
