### PR TITLE
INTERLOK-3555 #comment Update the pom url to point to the right doc

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -286,7 +286,7 @@ publishing {
       pom.withXml {
         asNode().appendNode("name", componentName)
         asNode().appendNode("description", "Configure Interlok to use clustered workflows and services")
-        asNode().appendNode("url", "https://interlok.adaptris.net/interlok-docs/advanced-vertx.html")
+        asNode().appendNode("url", "https://interlok.adaptris.net/interlok-docs/#/pages/advanced/advanced-vertx")
         def properties = asNode().appendNode("properties")
         properties.appendNode("target", "3.5.0+")
         properties.appendNode("tags", "vertx,clustered")


### PR DESCRIPTION
## Motivation
The documentation was broken since we changed the doc site

## Modification
Fix the doc url

## Result
The pom has a correct doc url

## Testing
Check that the new url exists in the POM file after running gradle generatePomFileForMavenJavaPublication.